### PR TITLE
Fix annotations: Do not mix type hint styles

### DIFF
--- a/funidata_utils/schemas/sisu/attainment.py
+++ b/funidata_utils/schemas/sisu/attainment.py
@@ -61,7 +61,7 @@ class GradeAverage(BaseModel):
 
 class CreditTransferInfo(BaseModel):
     educationalInstitutionUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('educational-institution'))]
-    internationalInstitutionUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('international-institution'))] | None = None
+    internationalInstitutionUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('international-institution'))] = None
     organisation: str | None = None
     creditTransferDate: datetime.date
 
@@ -90,8 +90,8 @@ class Attainment(ObjectWithDocumentState):
     gradeId: int
     gradeAverage: GradeAverage | None = None
     additionalInfo: LocalizedString | None = None
-    administrativeNote: Annotated[STRIPPED_STR, Field(min_length=1, max_length=SIS_MAX_MEDIUM_STRING_LENGTH)] | None = None
-    studyFieldUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('study-field'))] | None = None
+    administrativeNote: Annotated[STRIPPED_STR | None, Field(min_length=1, max_length=SIS_MAX_MEDIUM_STRING_LENGTH)] = None
+    studyFieldUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('study-field'))] = None
     workflowId: str | None = None
     moduleContentApplicationId: str | None = None
     creditTransferInfo: CreditTransferInfo | None = None
@@ -196,7 +196,7 @@ class DegreeProgrammeAttainment(Attainment):
     acceptorPersons: list[PersonWithAttainmentAcceptorType] = Field(default_factory=lambda x: [])
     acceptorOrganisationIds: conlist(str, min_length=1, max_length=SIS_MAX_MEDIUM_SET_SIZE)
     educationClassificationUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('education-classification'))]
-    secondaryEducationClassificationUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('education-classification'))] | None = None
+    secondaryEducationClassificationUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('education-classification'))] = None
     degreeTitleUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('degree-title'))]
-    honoraryTitleUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('honorary-title'))] | None = None
+    honoraryTitleUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('honorary-title'))] = None
     internationalContractualDegree: dict | None = None

--- a/funidata_utils/schemas/sisu/common.py
+++ b/funidata_utils/schemas/sisu/common.py
@@ -72,7 +72,7 @@ class LocalizedString(HashableBaseModel):
 
 class OrganisationRoleShareBase(HashableBaseModel):
     organisationId: OTM_ID_REGEX_VALIDATED_STR | None
-    educationalInstitutionUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('educational-institution'))] | None = None
+    educationalInstitutionUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('educational-institution'))] = None
     roleUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('organisation-role'))]
     share: Annotated[float, Field(strict=False, ge=0, le=1)]
 

--- a/funidata_utils/schemas/sisu/course_unit.py
+++ b/funidata_utils/schemas/sisu/course_unit.py
@@ -30,7 +30,7 @@ class StudyYearRange(BaseModel):
 
 class CompletionMethodRepeat(BaseModel):
     studyYearRange: StudyYearRange
-    yearInterval: Annotated[int, Field(gt=0)] | None = None
+    yearInterval: Annotated[int | None, Field(gt=0)] = None
     repeatPossibility: conlist(STRING_WITH_3_SLASHES, min_length=1, max_length=SIS_MAX_SMALL_SET_SIZE)
 
 
@@ -50,7 +50,7 @@ class CompletionMethod(BaseModel):
 
 class CourseUnitSubstitution(BaseModel):
     courseUnitGroupId: OTM_ID_REGEX_VALIDATED_STR
-    credits: Annotated[float, Field(ge=1)] | None = None
+    credits: Annotated[float | None, Field(ge=1)] = None
 
 
 class LiteratureName(BaseModel):
@@ -147,8 +147,8 @@ class CourseUnit(BaseModel):
     studyFields: conlist(Annotated[str, Field(pattern=sis_code_urn_pattern('study-field'))], max_length=SIS_MAX_SMALL_SET_SIZE, min_length=1)
     studyLevel: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('study-level'))]
     courseUnitType: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('course-unit-type'))]
-    subject: Annotated[str, Field(pattern=sis_code_urn_pattern('subject'))] | None = None
-    cefrLevel: Annotated[str, Field(pattern=sis_code_urn_pattern('cefr-level'))] | None = None
+    subject: Annotated[str | None, Field(pattern=sis_code_urn_pattern('subject'))] = None
+    cefrLevel: Annotated[str | None, Field(pattern=sis_code_urn_pattern('cefr-level'))] = None
     responsibilityInfos: conlist(PersonWithModuleResponsibilityInfoType, min_length=1, max_length=SIS_MAX_MEDIUM_SET_SIZE)
     organisations: conlist(OrganisationRoleShare, max_length=SIS_MAX_MEDIUM_SET_SIZE, min_length=1)
     possibleAttainmentLanguages: conlist(
@@ -158,8 +158,8 @@ class CourseUnit(BaseModel):
     )
     equivalentCoursesInfo: LocalizedString | None = None
     curriculumPeriodIds: conlist(OTM_ID_REGEX_VALIDATED_STR, max_length=SIS_MAX_MEDIUM_SET_SIZE, min_length=1)
-    customCodeUrns: Annotated[dict[str, list[str]], Field(min_length=1)] | None = None
+    customCodeUrns: Annotated[dict[str | None, list[str]], Field(min_length=1)] = None
     inclusionApplicationInstruction: LocalizedString | None = None
     cooperationNetworkDetails: CooperationNetworkDetails | None = None
-    s2r2Classification: Annotated[str, Field(pattern=sis_code_urn_pattern('subject'))] | None = None
+    s2r2Classification: Annotated[str | None, Field(pattern=sis_code_urn_pattern('subject'))] = None
     rdiCreditsEnabled: Literal['ENABLED', 'DISABLED']

--- a/funidata_utils/schemas/sisu/mobility_period.py
+++ b/funidata_utils/schemas/sisu/mobility_period.py
@@ -21,8 +21,8 @@ class MobilityPeriod(BaseModel):
     mobilityProgramDescription: str | None = None
     mobilityTypeUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('mobility-type'))]
     countryUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('country'))]
-    internationalInstitutionUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('international-institution'))] | None = None
+    internationalInstitutionUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('international-institution'))] = None
     organisation: str | None = None
-    mobilityStudyRightTypeUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('mobility-study-right-type'))] | None = None
+    mobilityStudyRightTypeUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('mobility-study-right-type'))] = None
     virtualMobilityType: Literal["None", "RemoteAttendance", "BlendedAttendance"] | None = None
     isCancelled: bool

--- a/funidata_utils/schemas/sisu/organisation.py
+++ b/funidata_utils/schemas/sisu/organisation.py
@@ -26,7 +26,7 @@ class Organisation(BaseModel):
     name: LocalizedString
     abbreviation: LocalizedString | None = None
     status: Literal['ACTIVE', 'INACTIVE']
-    educationalInstitutionUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('educational-institution'))] | None = None
+    educationalInstitutionUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('educational-institution'))] = None
     cooperationNetworkIdentifiers: CooperationNetworkIdentifiers | None = None
 
     @field_serializer('snapshotDateTime')

--- a/funidata_utils/schemas/sisu/private_person.py
+++ b/funidata_utils/schemas/sisu/private_person.py
@@ -50,10 +50,10 @@ class PrivatePerson(BaseModel):
     secondaryAddress: FinnishAddress | GenericAddress | None = None
     genderUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('gender'))]
     citizenshipUrns: set[CountryUrnStr] | None = None
-    motherTongueUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('language'))] | None = None
-    preferredLanguageUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('preferred-language'))] | None = None
+    motherTongueUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('language'))] = None
+    preferredLanguageUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('preferred-language'))] = None
     schoolEducationLanguageUrns: conset(SchoolEducationLangUrnStr, min_length=1) | None = None
-    municipalityUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('municipality'))] | None = None
+    municipalityUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('municipality'))] = None
     oppijanumero: str | None = None
     oids: list[str] = []
     dead: bool = False

--- a/funidata_utils/schemas/sisu/study_right.py
+++ b/funidata_utils/schemas/sisu/study_right.py
@@ -69,10 +69,10 @@ class StudyRightExtension(BaseModel):
     extensionStartDate: datetime.date
     grantDate: datetime.date
     workflowId: str | None = None
-    grantReason: Annotated[str, Field(min_length=1, max_length=SIS_MAX_LONG_STRING_LENGTH)] | None
+    grantReason: Annotated[str | None, Field(min_length=1, max_length=SIS_MAX_LONG_STRING_LENGTH)]
     grantedBy: str = Field(description='<MAGIC>PersonId', pattern=OTM_ID_REGEX_PATTERN)
     deleteDate: datetime.date | None = None
-    deleteReason: Annotated[str, Field(min_length=1, max_length=SIS_MAX_TERSE_STRING_LENGTH)] | None
+    deleteReason: Annotated[str | None, Field(min_length=1, max_length=SIS_MAX_TERSE_STRING_LENGTH)]
     deletedBy: str | None = Field(default=None, description='<MAGIC>PersonId', pattern=OTM_ID_REGEX_PATTERN)
 
     @model_validator(mode='after')
@@ -162,7 +162,7 @@ class StudyRight(BaseModel):
     phase2EducationLocationUrn: Optional[str] = None
     phase1InternationalContractualDegree: Optional[dict] = None
     phase2InternationalContractualDegree: Optional[dict] = None
-    admissionTypeUrn: Annotated[STRIPPED_STR, Field(pattern=sis_code_urn_pattern('admission-type'))] | None = None
+    admissionTypeUrn: Annotated[STRIPPED_STR | None, Field(pattern=sis_code_urn_pattern('admission-type'))] = None
     codeUrns: list[CodeUrnsStr]
     additionalInformation: Optional[dict] = None
     # basedOnEnrolmentRights: bool < Apparently removed from sisu model at some point in time


### PR DESCRIPTION
As per pydantic documentation, do not mix Field and `type` patterns.
regex replaced:
`Annotated\[([A-z]*),(.*)\]( \| None)` -> `Annotated[$1 | None,$2]`

```
class Model(BaseModel):
    field_bad: Annotated[int, Field(deprecated=True)] | None = None
    field_ok: Annotated[int | None, Field(deprecated=True)] = None
```

https://docs.pydantic.dev/latest/concepts/fields/#the-annotated-pattern